### PR TITLE
updated Cache creation to use only JSR107 features; added Infinispan

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,4 @@
 # Created by .ignore support plugin (hsz.mobi)
 .idea
 target
-/hazelcast.iml
+*.iml

--- a/pom.xml
+++ b/pom.xml
@@ -77,24 +77,42 @@
 
     <!-- Everything JCache API -->
     <dependency>
-      <groupId>org.apache.geronimo.specs</groupId>
-      <artifactId>geronimo-jcache_1.0_spec</artifactId>
-      <version>1.0-alpha-1</version>
+      <groupId>javax.cache</groupId>
+      <artifactId>cache-api</artifactId>
+      <version>1.0.0</version>
     </dependency>
 
-    <!-- Everything Hazelcast-->
+    <!-- Everything Hazelcast -->
     <dependency>
       <groupId>com.hazelcast</groupId>
       <artifactId>hazelcast-all</artifactId>
       <version>3.5</version>
+      <scope>runtime</scope>
     </dependency>
 
-    <!-- Everything eHCache-->
+    <!-- Everything eHCache
     <dependency>
       <groupId>net.sf.ehcache</groupId>
       <artifactId>ehcache</artifactId>
       <version>2.10.0</version>
+      <scope>runtime</scope>
     </dependency>
+    -->
+
+    <!-- Everything Infinispan
+    <dependency>
+      <groupId>org.infinispan</groupId>
+      <artifactId>infinispan-jcache</artifactId>
+      <version>7.2.3.Final</version>
+      <scope>runtime</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.infinispan</groupId>
+      <artifactId>infinispan-client-hotrod</artifactId>
+      <version>7.2.3.Final</version>
+      <scope>runtime</scope>
+    </dependency>
+    -->
 
     <!-- Complex object mapping -->
     <dependency>
@@ -115,6 +133,7 @@
       <groupId>org.apache.openejb</groupId>
       <artifactId>tomee-embedded</artifactId>
       <version>${version.tomee.test}</version>
+      <scope>test</scope>
     </dependency>
 
     <!--Required for WebServices and RESTful WebServices-->
@@ -122,11 +141,13 @@
       <groupId>org.apache.openejb</groupId>
       <artifactId>tomee-webservices</artifactId>
       <version>${version.tomee.test}</version>
+      <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>org.apache.openejb</groupId>
       <artifactId>tomee-jaxrs</artifactId>
       <version>${version.tomee.test}</version>
+      <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>org.jboss.arquillian.junit</groupId>

--- a/src/main/java/com/tomitribe/jcache/examples/producers/CacheProducer.java
+++ b/src/main/java/com/tomitribe/jcache/examples/producers/CacheProducer.java
@@ -24,7 +24,6 @@ import javax.enterprise.context.ApplicationScoped;
 import javax.enterprise.inject.Disposes;
 import javax.enterprise.inject.Produces;
 import javax.inject.Singleton;
-import java.net.URL;
 
 @ApplicationScoped
 public class CacheProducer {
@@ -33,22 +32,9 @@ public class CacheProducer {
     @Singleton
     @LocalCacheProvider
     public CacheManager createCacheManager() {
-
-        //Quick hack, but simple
-        final String provider = System.getProperty("tomee.cache.provider", "hazelcast");
-
-        if ("hazelcast".equalsIgnoreCase(provider)) {
-            return Caching
-                    .getCachingProvider("com.hazelcast.cache.impl.HazelcastServerCachingProvider")
-                    .getCacheManager();
-        } else if ("ehcache".equalsIgnoreCase(provider)) {
-
-            final URL url = getClass().getResource("/anotherconfigurationname.xml");
-            // CacheManager manager = CacheManager.newInstance(url);
-
-        } //TODO - More....
-
-        throw new UnsupportedOperationException("Unknown provider");
+        // property can be extracted to server configuration
+        System.setProperty("hazelcast.jcache.provider.type", "server");
+        return Caching.getCachingProvider().getCacheManager();
     }
 
     public void close(@Disposes @LocalCacheProvider final CacheManager instance) {

--- a/src/main/java/com/tomitribe/jcache/examples/service/ServiceApplication.java
+++ b/src/main/java/com/tomitribe/jcache/examples/service/ServiceApplication.java
@@ -17,15 +17,10 @@
 package com.tomitribe.jcache.examples.service;
 
 import javax.ws.rs.ApplicationPath;
-import java.util.Arrays;
-import java.util.HashSet;
-import java.util.Set;
 
 @ApplicationPath("/api")
 public class ServiceApplication extends javax.ws.rs.core.Application {
 
-    @Override
-    public Set<Class<?>> getClasses() {
-        return new HashSet<Class<?>>(Arrays.<Class<?>>asList(InterceptedService.class));
-    }
+    // no configuration needed
+
 }


### PR DESCRIPTION
Hi, as promised I've updated the Cache instantiation to use only JCache functionality. The JCache provider which is in the Classpath is taken. On TomEE you have to remove potential existing providers from lib/. Tested with TomEE 8.0.20.0. Also added Infinispan as potential provider.
